### PR TITLE
use dotmap to replace bunch

### DIFF
--- a/configs/simple_mnist_config.json
+++ b/configs/simple_mnist_config.json
@@ -1,15 +1,24 @@
 {
-  "exp_name": "simple_mnist",
-  "num_epochs": 20,
-  "learning_rate": 0.001,
-  "optimizer": "adam",
-  "batch_size": 64,
-  "validation_split":0.25,
-  "verbose_training": true,
-  "checkpoint_monitor": "val_loss",
-  "checkpoint_mode": "min",
-  "checkpoint_save_best_only": true,
-  "checkpoint_save_weights_only": true,
-  "checkpoint_verbose": true,
-  "tensorboard_write_graph": true
+  "exp": {
+    "name": "simple_mnist"
+  },
+  "model":{
+    "learning_rate": 0.001,
+    "optimizer": "adam"
+  },
+  "trainer":{
+    "num_epochs": 20,
+    "batch_size": 64,
+    "validation_split":0.25,
+    "verbose_training": true
+  },
+  "callbacks":{
+    "checkpoint_monitor": "val_loss",
+    "checkpoint_mode": "min",
+    "checkpoint_save_best_only": true,
+   "checkpoint_save_weights_only": true,
+    "checkpoint_verbose": true,
+    "tensorboard_write_graph": true
+  }
+
 }

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ from utils.config import process_config
 from utils.dirs import create_dirs
 from utils.utils import get_args
 
-
 def main():
     # capture the config path from the run arguments
     # then process the json configuration file
@@ -17,7 +16,7 @@ def main():
         exit(0)
 
     # create the experiments dirs
-    create_dirs([config.tensorboard_log_dir, config.checkpoint_dir])
+    create_dirs([config.callbacks.tensorboard_log_dir, config.callbacks.checkpoint_dir])
 
     print('Create the data generator.')
     data_loader = SimpleMnistDataLoader(config)

--- a/models/simple_mnist_model.py
+++ b/models/simple_mnist_model.py
@@ -16,6 +16,6 @@ class SimpleMnistModel(BaseModel):
 
         self.model.compile(
             loss='sparse_categorical_crossentropy',
-            optimizer=self.config.optimizer,
+            optimizer=self.config.model.optimizer,
             metrics=['acc'],
         )

--- a/trainers/simple_mnist_trainer.py
+++ b/trainers/simple_mnist_trainer.py
@@ -16,29 +16,29 @@ class SimpleMnistModelTrainer(BaseTrain):
     def init_callbacks(self):
         self.callbacks.append(
             ModelCheckpoint(
-                filepath=os.path.join(self.config.checkpoint_dir, '%s-{epoch:02d}-{val_loss:.2f}.hdf5' % self.config.exp_name),
-                monitor=self.config.checkpoint_monitor,
-                mode=self.config.checkpoint_mode,
-                save_best_only=self.config.checkpoint_save_best_only,
-                save_weights_only=self.config.checkpoint_save_weights_only,
-                verbose=self.config.checkpoint_verbose,
+                filepath=os.path.join(self.config.callbacks.checkpoint_dir, '%s-{epoch:02d}-{val_loss:.2f}.hdf5' % self.config.exp.name),
+                monitor=self.config.callbacks.checkpoint_monitor,
+                mode=self.config.callbacks.checkpoint_mode,
+                save_best_only=self.config.callbacks.checkpoint_save_best_only,
+                save_weights_only=self.config.callbacks.checkpoint_save_weights_only,
+                verbose=self.config.callbacks.checkpoint_verbose,
             )
         )
 
         self.callbacks.append(
             TensorBoard(
-                log_dir=self.config.tensorboard_log_dir,
-                write_graph=self.config.tensorboard_write_graph,
+                log_dir=self.config.callbacks.tensorboard_log_dir,
+                write_graph=self.config.callbacks.tensorboard_write_graph,
             )
         )
     
     def train(self):
         history = self.model.fit(
             self.data[0], self.data[1],
-            epochs=self.config.num_epochs,
-            verbose=self.config.verbose_training,
-            batch_size=self.config.batch_size,
-            validation_split=self.config.validation_split,
+            epochs=self.config.trainer.num_epochs,
+            verbose=self.config.trainer.verbose_training,
+            batch_size=self.config.trainer.batch_size,
+            validation_split=self.config.trainer.validation_split,
             callbacks=self.callbacks,
         )
         self.loss.extend(history.history['loss'])

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,5 +1,5 @@
 import json
-from bunch import Bunch
+from dotmap import DotMap
 import os
 import time
 
@@ -15,13 +15,13 @@ def get_config_from_json(json_file):
         config_dict = json.load(config_file)
 
     # convert the dictionary to a namespace using bunch lib
-    config = Bunch(config_dict)
+    config = DotMap(config_dict)
 
     return config, config_dict
 
 
 def process_config(json_file):
     config, _ = get_config_from_json(json_file)
-    config.tensorboard_log_dir = os.path.join("experiments", time.strftime("%Y-%m-%d/",time.localtime()), config.exp_name, "logs/")
-    config.checkpoint_dir = os.path.join("experiments", time.strftime("%Y-%m-%d/",time.localtime()), config.exp_name, "checkpoints/")
+    config.callbacks.tensorboard_log_dir = os.path.join("experiments", time.strftime("%Y-%m-%d/",time.localtime()), config.exp.name, "logs/")
+    config.callbacks.checkpoint_dir = os.path.join("experiments", time.strftime("%Y-%m-%d/",time.localtime()), config.exp.name, "checkpoints/")
     return config


### PR DESCRIPTION
Hi, @Ahmkel , I find a potential problem with this template, if we want this template more useful ~
here is the json file in our template 
```json
{
  "exp_name": "simple_mnist",
  "num_epochs": 20,
  "learning_rate": 0.001,
  "optimizer": "adam",
  "batch_size": 64,
  "validation_split":0.25,
  "verbose_training": true,
  "checkpoint_monitor": "val_loss",
  "checkpoint_mode": "min",
  "checkpoint_save_best_only": true,
  "checkpoint_save_weights_only": true,
  "checkpoint_verbose": true,
  "tensorboard_write_graph": true
}
```
sometimes more and more paramters may need to write into this json file, and it may becomes like this
```json
{
  "exp_name": "simple_mnist",
  "num_epochs": 20,
  "learning_rate": 0.001,
  "optimizer": "adam",
  "batch_size": 64,
  "validation_split":0.25,
  "verbose_training": true,
  "checkpoint_monitor": "val_loss",
  "checkpoint_mode": "min",
  "checkpoint_save_best_only": true,
  "checkpoint_save_weights_only": true,
  "checkpoint_verbose": true,
  "tensorboard_write_graph": true,
 "learning_rate": 0.001,
  "optimizer": "adam",
  "batch_size": 64,
  "validation_split":0.25,
"tensorboard_write_graph": true,
  "validation_split":0.25,
  "verbose_training": true,
  "checkpoint_monitor": "val_loss",
  "checkpoint_mode": "min",
"tensorboard_write_graph": true
}
``` 
json file will become long and messy, and we can write it in another way actually, like this
```json
{
  "exp":{
    "name": "simple_mnist"
  },
  "model":{
    "large_kernel_size": 10,
    "target_size": 224,
    "learning_rate": 1e-4,
    "momentum": 0.9,
    "decay":5e-4
  },
  "trainer":{
    "num_epochs": 100,
    "batch_size": 20,
    "step_per_epoch": 125,
    "dev_step": 25,
    "verbose_training": true
  },
  "callbacks":{
    "checkpoint_monitor": "val_loss",
    "checkpoint_mode": "min",
    "checkpoint_save_best_only": true,
    "checkpoint_save_weights_only": true,
    "checkpoint_verbose": 1,
    "tensorboard_write_graph": true
  }
```

However， the problem is we can not access the `name` parameters for `config.exp.name`，since the Bunch lib do not support automatic child Bunch creation, and correct one is `config.exp['name']`, which is ugly.

So, may be we can change the Bunch lib to other same functional lib to implement  a dot-accessible dictionary,

and I find a lib call DotMap, you can check this

[https://stackoverflow.com/questions/2352181/how-to-use-a-dot-to-access-members-of-dictionary](url)

I recommend to use DotMap instead.