### PR TITLE
Fix comet_ml import error in simple_mnist_trainer.py

### DIFF
--- a/trainers/simple_mnist_trainer.py
+++ b/trainers/simple_mnist_trainer.py
@@ -32,7 +32,7 @@ class SimpleMnistModelTrainer(BaseTrain):
             )
         )
 
-        if hasattr(self.config,"comet_api_key"):
+        if "comet_api_key" in self.config:
             from comet_ml import Experiment
             experiment = Experiment(api_key=self.config.comet_api_key, project_name=self.config.exp_name)
             experiment.disable_mp()


### PR DESCRIPTION
Fixes the "SyntaxError: Please import Comet before importing any keras modules" error in simple_mnist_trainer.py using the change suggested in https://github.com/Ahmkel/Keras-Project-Template/issues/8